### PR TITLE
Distribute ray weight on hits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.4)
 
 project(
   "ViennaRay"
-  VERSION 0.0.1)
+  VERSION 1.1.0)
 
 add_definitions(-DVIENNARAY_VERSION=${PROJECT_VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,11 @@ add_subdirectory(external/upstream)
 
 set(VIENNARAY_INCLUDE_DIRS "${${PROJECT_NAME}_SOURCE_DIR}/include")
 
+option(VIENNARAY_USE_WDIST "Use weighted distribution of ray weights." ON)
+if(VIENNARAY_USE_WDIST)
+  add_compile_definitions(VIENNARAY_USE_WDIST)
+endif(VIENNARAY_USE_WDIST)
+
 
 #################################################
 # BUILD EXAMPLES

--- a/Tests/traceInterface/traceInterface.cpp
+++ b/Tests/traceInterface/traceInterface.cpp
@@ -27,9 +27,12 @@ int main() {
   rayTracer.setBoundaryConditions(boundaryConds);
   rayTracer.setSourceDirection(rayTraceDirection::POS_Z);
   rayTracer.setNumberOfRaysPerPoint(10);
-  rayTracer.setUseRandomSeeds(true);
+  rayTracer.setUseRandomSeeds(false);
   rayTracer.setMaterialIds(matIds);
   rayTracer.apply();
+
+  auto info = rayTracer.getRayTraceInfo();
+  RAYTEST_ASSERT(info.numRays == 4410);
 
   return 0;
 }

--- a/cmake/ViennaRayConfig.cmake.in
+++ b/cmake/ViennaRayConfig.cmake.in
@@ -24,6 +24,10 @@ else(ViennaRay_COMMON_TARGET)
   SET(VIENNARAY_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@@CMAKE_INSTALL_INCLUDEDIR@")
 endif()
 
+if(@VIENNARAY_USE_WDIST@)
+  add_compile_definitions(VIENNARAY_USE_WDIST)
+endif(@VIENNARAY_USE_WDIST@)
+
 set(embree_DIR @embree_DIR@)
 find_package(embree 3.0 PATHS ${embree_DIR} REQUIRED)
 list(APPEND VIENNARAY_LIBRARIES embree)

--- a/include/rayParticle.hpp
+++ b/include/rayParticle.hpp
@@ -48,7 +48,6 @@ public:
                                 const rayTriple<NumericType> &rayDir,
                                 const rayTriple<NumericType> &geomNormal,
                                 const unsigned int primID, const int materialId,
-                                const size_t numDiscsHit,
                                 rayTracingData<NumericType> &localData,
                                 const rayTracingData<NumericType> *globalData,
                                 rayRNG &Rng) = 0;
@@ -88,7 +87,6 @@ public:
   surfaceCollision(NumericType rayWeight, const rayTriple<NumericType> &rayDir,
                    const rayTriple<NumericType> &geomNormal,
                    const unsigned int primID, const int materialId,
-                   const size_t numDiscsHit,
                    rayTracingData<NumericType> &localData,
                    const rayTracingData<NumericType> *globalData,
                    rayRNG &Rng) override { // collect data for this hit
@@ -127,7 +125,6 @@ public:
                         const rayTriple<NumericType> &rayDir,
                         const rayTriple<NumericType> &geomNormal,
                         const unsigned int primID, const int materialId,
-                        const size_t numDiscsHit,
                         rayTracingData<NumericType> &localData,
                         const rayTracingData<NumericType> *globalData,
                         rayRNG &Rng) override final {}

--- a/include/rayParticle.hpp
+++ b/include/rayParticle.hpp
@@ -48,6 +48,7 @@ public:
                                 const rayTriple<NumericType> &rayDir,
                                 const rayTriple<NumericType> &geomNormal,
                                 const unsigned int primID, const int materialId,
+                                const size_t numDiscsHit,
                                 rayTracingData<NumericType> &localData,
                                 const rayTracingData<NumericType> *globalData,
                                 rayRNG &Rng) = 0;
@@ -87,6 +88,7 @@ public:
   surfaceCollision(NumericType rayWeight, const rayTriple<NumericType> &rayDir,
                    const rayTriple<NumericType> &geomNormal,
                    const unsigned int primID, const int materialId,
+                   const size_t numDiscsHit,
                    rayTracingData<NumericType> &localData,
                    const rayTracingData<NumericType> *globalData,
                    rayRNG &Rng) override { // collect data for this hit
@@ -125,6 +127,7 @@ public:
                         const rayTriple<NumericType> &rayDir,
                         const rayTriple<NumericType> &geomNormal,
                         const unsigned int primID, const int materialId,
+                        const size_t numDiscsHit,
                         rayTracingData<NumericType> &localData,
                         const rayTracingData<NumericType> *globalData,
                         rayRNG &Rng) override final {}

--- a/include/rayTrace.hpp
+++ b/include/rayTrace.hpp
@@ -29,6 +29,7 @@ private:
   rayHitCounter<NumericType> mHitCounter;
   rayTracingData<NumericType> mLocalData;
   rayTracingData<NumericType> *mGlobalData = nullptr;
+  rayTraceInfo mRTInfo;
 
 public:
   rayTrace() : mDevice(rtcNewDevice("hugepages=1")) {}
@@ -72,6 +73,7 @@ public:
     tracer.calcFlux(mCalcFlux);
     tracer.setTracingData(&mLocalData, mGlobalData);
     tracer.setHitCounter(&mHitCounter);
+    tracer.setRayTraceInfo(&mRTInfo);
     tracer.apply();
 
     boundary.releaseGeometry();
@@ -188,6 +190,8 @@ public:
   rayTracingData<NumericType> *getGlobalData() { return mGlobalData; }
 
   void setGlobalData(rayTracingData<NumericType> &data) { mGlobalData = &data; }
+
+  rayTraceInfo getRayTraceInfo() { return mRTInfo; }
 
 private:
   void extractFlux() {

--- a/include/rayTraceKernel.hpp
+++ b/include/rayTraceKernel.hpp
@@ -201,22 +201,24 @@ public:
           const auto &primID = rayHit.hit.primID;
           const auto materialID = mGeometry.getMaterialId(primID);
 
-          particle->surfaceCollision(rayWeight, rayDir, geomNormal, primID,
-                                     materialID, myLocalData, globalData,
-                                     RngState5);
-
           // Check for additional intersections
           std::vector<unsigned int> intIds;
           for (const auto &id : mGeometry.getNeighborIndicies(primID)) {
-            const auto matID = mGeometry.getMaterialId(id);
-
             if (checkLocalIntersection(ray, id)) {
-              const auto normal = mGeometry.getPrimNormal(id);
-              particle->surfaceCollision(rayWeight, rayDir, normal, id, matID,
-                                         myLocalData, globalData, RngState5);
-              if (calcFlux)
-                intIds.push_back(id);
+              intIds.push_back(id);
             }
+          }
+          const size_t numDiscsHit = intIds.size() + 1;
+
+          particle->surfaceCollision(rayWeight, rayDir, geomNormal, primID,
+                                     materialID, numDiscsHit, myLocalData, globalData,
+                                     RngState5);
+
+          for (const auto &id : intIds) {
+            const auto matID = mGeometry.getMaterialId(id);
+            const auto normal = mGeometry.getPrimNormal(id);
+            particle->surfaceCollision(rayWeight, rayDir, normal, id, matID, numDiscsHit,
+                                        myLocalData, globalData, RngState5);
           }
 
           const auto stickingnDirection =

--- a/include/rayUtil.hpp
+++ b/include/rayUtil.hpp
@@ -22,6 +22,15 @@ template <typename NumericType> using rayQuadruple = std::array<NumericType, 4>;
 // embree uses float internally
 using rtcNumericType = float;
 
+struct rayTraceInfo {
+  size_t numRays;
+  size_t totalRaysTraced;
+  size_t totalDiskHits;
+  size_t nonGeometryHits;
+  size_t geometryHits;
+  double time;
+};
+
 namespace rayInternal {
 constexpr double PI = 3.14159265358979323846;
 constexpr double mDiscFactor = 0.5 * 1.7320508 * (1 + 1e-5);


### PR DESCRIPTION
Ray weights are now distributed on each disk which is intersected.
The weight is equally distributed on each disk per default.
With a compile time option, one can use a weighted distribution, where the portion of weight that is added is weighted by the distance to the disk origin.