### PR TITLE
Added support for building with versions of embree that were compiled with the ray masking option enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ if(DEFINED ${embree_DIR})
   set(embree_DIR ${embree_DIR} CACHE PATH "Path to embree installation")
 endif()
 
+# Enable Ray Masking if embree is compiled with ray masking enabled
+set(VIENNARAY_USE_RAY_MASKING EMBREE_RAY_MASK)
+
 ##########################################################################################
 ### If one wants to uses an Intel SPMD Compiler, the one has to set that here
 ##########################################################################################

--- a/cmake/ViennaRayConfig.cmake.in
+++ b/cmake/ViennaRayConfig.cmake.in
@@ -32,4 +32,9 @@ set(embree_DIR @embree_DIR@)
 find_package(embree 3.0 PATHS ${embree_DIR} REQUIRED)
 list(APPEND VIENNARAY_LIBRARIES embree)
 
+# Enable Ray Masking if embree is compiled with ray masking enabled
+if(@VIENNARAY_USE_RAY_MASKING@)
+  add_compile_definitions(VIENNARAY_USE_RAY_MASKING)
+endif(@VIENNARAY_USE_RAY_MASKING@)
+
 check_required_components("@PROJECT_NAME@")

--- a/include/rayBoundary.hpp
+++ b/include/rayBoundary.hpp
@@ -214,6 +214,10 @@ private:
       primNormals[idx] = triNorm;
     }
 
+#ifdef VIENNARAY_USE_RAY_MASKING
+    rtcSetGeometryMask(mRtcBoundary, -1);
+#endif
+
     rtcCommitGeometry(mRtcBoundary);
     assert(rtcGetDeviceError(pDevice) == RTC_ERROR_NONE &&
            "RTC Error: rtcCommitGeometry");

--- a/include/rayGeometry.hpp
+++ b/include/rayGeometry.hpp
@@ -86,6 +86,10 @@ public:
       }
     }
 
+#ifdef VIENNARAY_USE_RAY_MASKING
+    rtcSetGeometryMask(mRTCGeometry, -1);
+#endif
+
     rtcCommitGeometry(mRTCGeometry);
     assert(rtcGetDeviceError(pDevice) == RTC_ERROR_NONE &&
            "RTC Error: rtcCommitGeometry");

--- a/include/rayTraceKernel.hpp
+++ b/include/rayTraceKernel.hpp
@@ -137,6 +137,10 @@ public:
         mSource.fillRay(rayHit.ray, idx, RngState1, RngState2, RngState3,
                         RngState4); // fills also tnear
 
+#ifdef VIENNARAY_USE_RAY_MASKING
+        rayHit.ray.mask = -1;
+#endif
+
         if constexpr (PRINT_PROGRESS) {
           printProgress(progressCount);
         }


### PR DESCRIPTION
Some Linux distributions (e.g. Arch) ship embree with ray masking enabled. In those cases the compile time option VIENNARAY_USE_RAY_MASKING will be enabled, which sets the mask on the boundary, the geometry and the ray to all ones (thus the original behavior of ViennaRay is preserved).