### PR TITLE
Added relative error checking

### DIFF
--- a/Tests/errorChecking/CMakeLists.txt
+++ b/Tests/errorChecking/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.4)
+
+project("errorChecking")
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC "${VIENNARAY_INCLUDE_DIRS}")
+target_link_libraries(${PROJECT_NAME} PRIVATE ${VIENNARAY_LIBRARIES})
+
+add_dependencies(buildTests ${PROJECT_NAME})
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/Tests/errorChecking/errorChecking.cpp
+++ b/Tests/errorChecking/errorChecking.cpp
@@ -1,0 +1,35 @@
+#include <rayParticle.hpp>
+#include <rayTestAsserts.hpp>
+#include <rayTrace.hpp>
+
+int main() {
+  constexpr int D = 3;
+  using NumericType = float;
+  omp_set_num_threads(4);
+
+  NumericType extent = 5;
+  NumericType gridDelta = 0.5;
+  std::vector<std::array<NumericType, D>> points;
+  std::vector<std::array<NumericType, D>> normals;
+  rayInternal::createPlaneGrid(gridDelta, extent, {0, 1, 2}, points, normals);
+
+  rayTraceBoundary boundaryConds[D];
+  boundaryConds[0] = rayTraceBoundary::REFLECTIVE;
+  boundaryConds[1] = rayTraceBoundary::REFLECTIVE;
+  boundaryConds[2] = rayTraceBoundary::REFLECTIVE;
+  auto particle = std::make_unique<rayTestParticle<NumericType>>();
+
+  rayTrace<NumericType, D> rayTracer;
+  rayTracer.setParticleType(particle);
+  rayTracer.setGeometry(points, normals, gridDelta);
+  rayTracer.setBoundaryConditions(boundaryConds);
+  rayTracer.setSourceDirection(rayTraceDirection::POS_Z);
+  rayTracer.setNumberOfRaysPerPoint(10);
+  rayTracer.setUseRandomSeeds(false);
+  rayTracer.apply();
+
+  auto info = rayTracer.getRayTraceInfo();
+  RAYTEST_ASSERT(info.warning);
+
+  return 0;
+}

--- a/include/rayTrace.hpp
+++ b/include/rayTrace.hpp
@@ -298,6 +298,7 @@ private:
       }
     }
     if (!allPassed) {
+      mRTInfo.warning = true;
       rayMessage::getInstance()
           .addWarning(
               "Large relative error detected. Consider using more rays.")
@@ -307,19 +308,23 @@ private:
 
   void checkSettings() {
     if (mParticle == nullptr) {
+      mRTInfo.error = true;
       rayMessage::getInstance().addError(
           "No particle was specified in rayTrace. Aborting.");
     }
     if (mGeometry.checkGeometryEmpty()) {
+      mRTInfo.error = true;
       rayMessage::getInstance().addError(
           "No geometry was passed to rayTrace. Aborting.");
     }
     if ((D == 2 && mSourceDirection == rayTraceDirection::POS_Z) ||
         (D == 2 && mSourceDirection == rayTraceDirection::NEG_Z)) {
+      mRTInfo.error = true;
       rayMessage::getInstance().addError(
           "Invalid source direction in 2D geometry. Aborting.");
     }
     if (mDiskRadius > mGridDelta) {
+      mRTInfo.warning = true;
       rayMessage::getInstance()
           .addWarning("Disk radius should be smaller than grid delta. Hit "
                       "count normalization not correct.")

--- a/include/rayTrace.hpp
+++ b/include/rayTrace.hpp
@@ -57,6 +57,9 @@ public:
     tracer.setRayTraceInfo(&mRTInfo);
     tracer.apply();
 
+    if (mCheckError)
+      checkRelativeError();
+
     boundary.releaseGeometry();
   }
 
@@ -145,6 +148,15 @@ public:
   /// functions getTotalFlux(), getNormalizedFlux(), getHitCounts() and
   /// getRelativeError() can not be used.
   void setCalculateFlux(const bool calcFlux) { mCalcFlux = calcFlux; }
+
+  /// Set whether to check the relative error after a tracing. If the relative
+  /// error at a surface point is larger than 0.05 a warning is printed. The
+  /// value 0.05 is reported in: "A General Monte Carlo N-Particle Transport
+  /// Code, Version 5, Vol. I Overview and Theory, LA - UR - 03 - 1987, Los
+  /// Alamos Nat.Lab., Los Alamos, NM"
+  void setCheckRelativeError(const bool checkError) {
+    mCheckError = checkError;
+  }
 
   /// Returns the total flux on each disk.
   std::vector<NumericType> getTotalFlux() const {
@@ -263,6 +275,36 @@ private:
     return sourceArea;
   }
 
+  void checkRelativeError() {
+    auto error = getRelativeError();
+    int numThreads = omp_get_max_threads();
+    std::vector<bool> passed(numThreads, true);
+
+#pragma omp parallel shared(error, passed)
+    {
+      int threadId = omp_get_thread_num();
+#pragma omp for
+      for (size_t i = 0; i < error.size(); i++) {
+        if (error[i] > 0.05) {
+          passed[threadId] = false;
+        }
+      }
+    }
+    bool allPassed = true;
+    for (int i = 0; i < numThreads; i++) {
+      if (!passed[i]) {
+        allPassed = false;
+        break;
+      }
+    }
+    if (!allPassed) {
+      rayMessage::getInstance()
+          .addWarning(
+              "Large relative error detected. Consider using more rays.")
+          .print();
+    }
+  }
+
   void checkSettings() {
     if (mParticle == nullptr) {
       rayMessage::getInstance().addError(
@@ -307,6 +349,7 @@ private:
   bool mUseRandomSeeds = false;
   size_t mRunNumber = 0;
   bool mCalcFlux = true;
+  bool mCheckError = true;
   rayHitCounter<NumericType> mHitCounter;
   rayTracingData<NumericType> mLocalData;
   rayTracingData<NumericType> *mGlobalData = nullptr;

--- a/include/rayTrace.hpp
+++ b/include/rayTrace.hpp
@@ -277,14 +277,15 @@ private:
 
   void checkRelativeError() {
     auto error = getRelativeError();
+    const int numPoints = error.size();
     int numThreads = omp_get_max_threads();
     std::vector<bool> passed(numThreads, true);
 
-#pragma omp parallel shared(error, passed)
+#pragma omp parallel shared(error, numPoints, passed)
     {
       int threadId = omp_get_thread_num();
 #pragma omp for
-      for (size_t i = 0; i < error.size(); i++) {
+      for (int i = 0; i < numPoints; i++) {
         if (error[i] > 0.05) {
           passed[threadId] = false;
         }

--- a/include/rayUtil.hpp
+++ b/include/rayUtil.hpp
@@ -32,6 +32,8 @@ struct rayTraceInfo {
   size_t nonGeometryHits;
   size_t geometryHits;
   double time;
+  bool warning = false;
+  bool error = false;
 };
 
 namespace rayInternal {


### PR DESCRIPTION
Added automatic relative error checking after tracing. This option can be disabled and is now enabled by default. Closes #30 