### PR TITLE
Change particle local data size evaluation and particle specific seed in tracing kernel

### DIFF
--- a/Tests/createRay/createRay.cpp
+++ b/Tests/createRay/createRay.cpp
@@ -33,9 +33,6 @@ int main() {
   auto rng = rayRNG{};
   unsigned seed = 31;
   rayRNG rngstate1(seed + 0);
-  rayRNG rngstate2(seed + 1);
-  rayRNG rngstate3(seed + 2);
-  rayRNG rngstate4(seed + 3);
 
   {
     auto direction = rayTraceDirection::POS_Z;
@@ -49,7 +46,7 @@ int main() {
     alignas(128) auto rayhit =
         RTCRayHit{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (size_t i = 0; i < 10; ++i) {
-      source.fillRay(rayhit.ray, 0, rngstate1, rngstate2, rngstate3, rngstate4);
+      source.fillRay(rayhit.ray, 0, rngstate1);
       RAYTEST_ASSERT(rayhit.ray.dir_z < 0.)
       RAYTEST_ASSERT_ISCLOSE(rayhit.ray.org_z, (1. + 2 * gridDelta), eps)
     }
@@ -67,7 +64,7 @@ int main() {
     alignas(128) auto rayhit =
         RTCRayHit{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (size_t i = 0; i < 10; ++i) {
-      source.fillRay(rayhit.ray, 0, rngstate1, rngstate2, rngstate3, rngstate4);
+      source.fillRay(rayhit.ray, 0, rngstate1);
       RAYTEST_ASSERT(rayhit.ray.dir_z > 0.)
       RAYTEST_ASSERT_ISCLOSE(rayhit.ray.org_z, (-1. - 2 * gridDelta), eps)
     }
@@ -85,7 +82,7 @@ int main() {
     alignas(128) auto rayhit =
         RTCRayHit{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (size_t i = 0; i < 10; ++i) {
-      source.fillRay(rayhit.ray, 0, rngstate1, rngstate2, rngstate3, rngstate4);
+      source.fillRay(rayhit.ray, 0, rngstate1);
       RAYTEST_ASSERT(rayhit.ray.dir_x < 0.)
       RAYTEST_ASSERT_ISCLOSE(rayhit.ray.org_x, (1. + 2 * gridDelta), eps)
     }
@@ -103,7 +100,7 @@ int main() {
     alignas(128) auto rayhit =
         RTCRayHit{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (size_t i = 0; i < 10; ++i) {
-      source.fillRay(rayhit.ray, 0, rngstate1, rngstate2, rngstate3, rngstate4);
+      source.fillRay(rayhit.ray, 0, rngstate1);
       RAYTEST_ASSERT(rayhit.ray.dir_x > 0.)
       RAYTEST_ASSERT_ISCLOSE(rayhit.ray.org_x, (-1. - 2 * gridDelta), eps)
     }
@@ -121,7 +118,7 @@ int main() {
     alignas(128) auto rayhit =
         RTCRayHit{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (size_t i = 0; i < 10; ++i) {
-      source.fillRay(rayhit.ray, 0, rngstate1, rngstate2, rngstate3, rngstate4);
+      source.fillRay(rayhit.ray, 0, rngstate1);
       RAYTEST_ASSERT(rayhit.ray.dir_y < 0.)
       RAYTEST_ASSERT_ISCLOSE(rayhit.ray.org_y, (1. + 2 * gridDelta), eps)
     }
@@ -139,7 +136,7 @@ int main() {
     alignas(128) auto rayhit =
         RTCRayHit{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (size_t i = 0; i < 10; ++i) {
-      source.fillRay(rayhit.ray, 0, rngstate1, rngstate2, rngstate3, rngstate4);
+      source.fillRay(rayhit.ray, 0, rngstate1);
       RAYTEST_ASSERT(rayhit.ray.dir_y > 0.)
       RAYTEST_ASSERT_ISCLOSE(rayhit.ray.org_y, (-1. - 2 * gridDelta), eps)
     }

--- a/Tests/createSourceGrid/createSourceGrid.cpp
+++ b/Tests/createSourceGrid/createSourceGrid.cpp
@@ -26,10 +26,7 @@ int main() {
   auto grid = rayInternal::createSourceGrid<NumericType, D>(
       boundingBox, points.size(), gridDelta, traceSettings);
 
-  rayRNG rngstate1(0);
-  rayRNG rngstate2(1);
-  rayRNG rngstate3(2);
-  rayRNG rngstate4(3);
+  rayRNG rngstate(0);
   {
     // build source in positive z direction;
     auto source = raySourceGrid<NumericType, D>(grid, 1., traceSettings);
@@ -37,7 +34,7 @@ int main() {
     alignas(128) auto rayhit =
         RTCRayHit{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     for (size_t i = 0; i < numGridPoints; ++i) {
-      source.fillRay(rayhit.ray, i, rngstate1, rngstate2, rngstate3, rngstate4);
+      source.fillRay(rayhit.ray, i, rngstate);
 
       RAYTEST_ASSERT(rayhit.ray.dir_z < 0.)
       RAYTEST_ASSERT_ISCLOSE(rayhit.ray.org_z, (1. + 2 * gridDelta), eps)

--- a/include/rayParticle.hpp
+++ b/include/rayParticle.hpp
@@ -53,13 +53,12 @@ public:
                                 const rayTracingData<NumericType> *globalData,
                                 rayRNG &Rng) = 0;
 
-  /// Set the number of required data vectors for this particle to
-  /// collect data.
-  virtual int getRequiredLocalDataSize() const = 0;
-
   /// Set the power of the cosine source distribution for this particle.
   virtual NumericType getSourceDistributionPower() const = 0;
 
+  /// Set the number of required data vectors for this particle to
+  /// collect data. If an empty vector is returned, no local data will be
+  /// provided
   virtual std::vector<std::string> getLocalDataLabels() const = 0;
 
   virtual void logData(rayDataLog<NumericType> &log) = 0;
@@ -94,10 +93,9 @@ public:
                    const rayTracingData<NumericType> *globalData,
                    rayRNG &Rng) override { // collect data for this hit
   }
-  virtual int getRequiredLocalDataSize() const override { return 0; }
   virtual NumericType getSourceDistributionPower() const override { return 1.; }
   virtual std::vector<std::string> getLocalDataLabels() const override {
-    return std::vector<std::string>(getRequiredLocalDataSize(), "localData");
+    return {};
   }
   virtual void logData(rayDataLog<NumericType> &log) override {}
 
@@ -133,12 +131,10 @@ public:
                         const rayTracingData<NumericType> *globalData,
                         rayRNG &Rng) override final {}
 
-  int getRequiredLocalDataSize() const override final { return 0; }
-
   NumericType getSourceDistributionPower() const override final { return 1.; }
 
   std::vector<std::string> getLocalDataLabels() const override final {
-    return std::vector<std::string>{};
+    return {};
   }
 
   void logData(rayDataLog<NumericType> &log) override final {}

--- a/include/rayRNG.hpp
+++ b/include/rayRNG.hpp
@@ -4,7 +4,26 @@
 #include <memory>
 #include <random>
 
-/// Use meresenne twister 19937 as random number generator.
+/// Use mersenne twister 19937 as random number generator.
 typedef std::mt19937_64 rayRNG;
+
+namespace rayInternal {
+
+// tiny encryption algortihm
+template <unsigned int N>
+static unsigned int tea(unsigned int val0, unsigned int val1) {
+  unsigned int v0 = val0;
+  unsigned int v1 = val1;
+  unsigned int s0 = 0;
+
+  for (unsigned int n = 0; n < N; n++) {
+    s0 += 0x9e3779b9;
+    v0 += ((v1 << 4) + 0xa341316c) ^ (v1 + s0) ^ ((v1 >> 5) + 0xc8013ea4);
+    v1 += ((v0 << 4) + 0xad90777d) ^ (v0 + s0) ^ ((v0 >> 5) + 0x7e95761e);
+  }
+
+  return v0;
+}
+} // namespace rayInternal
 
 #endif // RAY_RNG_HPP

--- a/include/raySource.hpp
+++ b/include/raySource.hpp
@@ -9,9 +9,7 @@
 template <typename NumericType, int D> class raySource {
 public:
   virtual ~raySource() {}
-  virtual void fillRay(RTCRay &ray, const size_t idx, rayRNG &RngState1,
-                       rayRNG &RngState2, rayRNG &RngState3,
-                       rayRNG &RngState4) {}
+  virtual void fillRay(RTCRay &ray, const size_t idx, rayRNG &RngState) {}
   virtual size_t getNumPoints() const { return 0; }
   virtual void printIndexCounter(){};
 };

--- a/include/raySourceGrid.hpp
+++ b/include/raySourceGrid.hpp
@@ -17,13 +17,11 @@ public:
         ee(((NumericType)2) / (passedCosinePower + 1)),
         indexCounter(sourceGrid.size(), 0) {}
 
-  void fillRay(RTCRay &ray, const size_t idx, rayRNG &RngState1,
-               rayRNG &RngState2, rayRNG &RngState3,
-               rayRNG &RngState4) override final {
+  void fillRay(RTCRay &ray, const size_t idx, rayRNG &RngState) override final {
     auto index = idx % mNumPoints;
     indexCounter[index]++;
     auto origin = mSourceGrid[idx % mNumPoints];
-    auto direction = getDirection(RngState3, RngState4);
+    auto direction = getDirection(RngState);
 
 #ifdef ARCH_X86
     reinterpret_cast<__m128 &>(ray) =
@@ -53,11 +51,11 @@ public:
   }
 
 private:
-  rayTriple<NumericType> getDirection(rayRNG &RngState1, rayRNG &RngState2) {
+  rayTriple<NumericType> getDirection(rayRNG &RngState) {
     rayTriple<NumericType> direction{0., 0., 0.};
     std::uniform_real_distribution<NumericType> uniDist;
-    auto r1 = uniDist(RngState1);
-    auto r2 = uniDist(RngState2);
+    auto r1 = uniDist(RngState);
+    auto r2 = uniDist(RngState);
 
     NumericType tt = pow(r2, ee);
     direction[rayDir] = posNeg * sqrtf(tt);

--- a/include/raySourceRandom.hpp
+++ b/include/raySourceRandom.hpp
@@ -15,11 +15,9 @@ public:
         minMax(pTraceSettings[3]), posNeg(pTraceSettings[4]),
         ee(((NumericType)2) / (pCosinePower + 1)), mNumPoints(pNumPoints) {}
 
-  void fillRay(RTCRay &ray, const size_t idx, rayRNG &RngState1,
-               rayRNG &RngState2, rayRNG &RngState3,
-               rayRNG &RngState4) override final {
-    auto origin = getOrigin(RngState1, RngState2);
-    auto direction = getDirection(RngState3, RngState4);
+  void fillRay(RTCRay &ray, const size_t idx, rayRNG &RngState) override final {
+    auto origin = getOrigin(RngState);
+    auto direction = getDirection(RngState);
 
 #ifdef ARCH_X86
     reinterpret_cast<__m128 &>(ray) =
@@ -43,10 +41,10 @@ public:
   size_t getNumPoints() const override final { return mNumPoints; }
 
 private:
-  rayTriple<NumericType> getOrigin(rayRNG &RngState1, rayRNG &RngState2) {
+  rayTriple<NumericType> getOrigin(rayRNG &RngState) {
     rayTriple<NumericType> origin{0., 0., 0.};
     std::uniform_real_distribution<NumericType> uniDist;
-    auto r1 = uniDist(RngState1);
+    auto r1 = uniDist(RngState);
 
     origin[rayDir] = bdBox[minMax][rayDir];
     origin[firstDir] =
@@ -55,7 +53,7 @@ private:
     if constexpr (D == 2) {
       origin[secondDir] = 0.;
     } else {
-      auto r2 = uniDist(RngState2);
+      auto r2 = uniDist(RngState);
       origin[secondDir] = bdBox[0][secondDir] +
                           (bdBox[1][secondDir] - bdBox[0][secondDir]) * r2;
     }
@@ -63,11 +61,11 @@ private:
     return origin;
   }
 
-  rayTriple<NumericType> getDirection(rayRNG &RngState1, rayRNG &RngState2) {
+  rayTriple<NumericType> getDirection(rayRNG &RngState) {
     rayTriple<NumericType> direction{0., 0., 0.};
     std::uniform_real_distribution<NumericType> uniDist;
-    auto r1 = uniDist(RngState1);
-    auto r2 = uniDist(RngState2);
+    auto r1 = uniDist(RngState);
+    auto r2 = uniDist(RngState);
 
     const NumericType tt = pow(r2, ee);
     direction[rayDir] = posNeg * sqrtf(tt);

--- a/include/rayTrace.hpp
+++ b/include/rayTrace.hpp
@@ -37,13 +37,13 @@ public:
         boundingBox, mParticle->getSourceDistributionPower(), traceSettings,
         mGeometry.getNumPoints());
 
-    auto localDataLabes = mParticle->getLocalDataLabels();
+    auto localDataLabels = mParticle->getLocalDataLabels();
     if (!localDataLabels.empty()) {
-      mLocalData.setNumberOfVectorData(localDataLabes.size());
+      mLocalData.setNumberOfVectorData(localDataLabels.size());
       auto numPoints = mGeometry.getNumPoints();
-      auto localDataLabes = mParticle->getLocalDataLabels();
-      for (int i = 0; i < localDataLabes.size(); ++i) {
-        mLocalData.setVectorData(i, numPoints, 0., localDataLabes[i]);
+      auto localDataLabels = mParticle->getLocalDataLabels();
+      for (int i = 0; i < localDataLabels.size(); ++i) {
+        mLocalData.setVectorData(i, numPoints, 0., localDataLabels[i]);
       }
     }
 

--- a/include/rayTrace.hpp
+++ b/include/rayTrace.hpp
@@ -37,12 +37,12 @@ public:
         boundingBox, mParticle->getSourceDistributionPower(), traceSettings,
         mGeometry.getNumPoints());
 
-    auto numberOfLocalData = mParticle->getRequiredLocalDataSize();
-    if (numberOfLocalData) {
-      mLocalData.setNumberOfVectorData(numberOfLocalData);
+    auto localDataLabes = mParticle->getLocalDataLabels();
+    if (!localDataLabels.empty()) {
+      mLocalData.setNumberOfVectorData(localDataLabes.size());
       auto numPoints = mGeometry.getNumPoints();
       auto localDataLabes = mParticle->getLocalDataLabels();
-      for (int i = 0; i < numberOfLocalData; ++i) {
+      for (int i = 0; i < localDataLabes.size(); ++i) {
         mLocalData.setVectorData(i, numPoints, 0., localDataLabes[i]);
       }
     }


### PR DESCRIPTION
- The amount of local data required per particle is now determined by the size of the vector containing the local data labels
- The RNG seeds are now particle-specific. This ensures reproducibility with multiple threads.