### PR TITLE
Upgrade to embree 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: 🧪 Run Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,19 +25,19 @@ include("cmake/openmp.cmake")
 set(VIENNARAY_EMBREE_VERSION 4)
 find_package(embree ${VIENNARAY_EMBREE_VERSION} QUIET)
 set(VIENNARAY_SYSTEM_EMBREE ${embree_FOUND})
-if (VIENNARAY_SYSTEM_EMBREE)
+if(VIENNARAY_SYSTEM_EMBREE)
   message(STATUS "[ViennaRay] Found embree 4 system installation")
 else(VIENNARAY_SYSTEM_EMBREE)
   # look for embree 3
   find_package(embree 3 QUIET)
   set(VIENNARAY_SYSTEM_EMBREE ${embree_FOUND})
-  if (VIENNARAY_SYSTEM_EMBREE)
+  if(VIENNARAY_SYSTEM_EMBREE)
     message(STATUS "[ViennaRay] Found embree 3 system installation")
     set(VIENNARAY_EMBREE_VERSION 3)
   endif()
 endif()
 
-if (NOT VIENNARAY_SYSTEM_EMBREE)
+if(NOT VIENNARAY_SYSTEM_EMBREE)
   message(STATUS "[ViennaRay] Using remote embree")
 endif()
 
@@ -55,6 +55,8 @@ set_target_properties(
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON
              WINDOWS_EXPORT_ALL_SYMBOLS ON)
+target_compile_definitions(${PROJECT_NAME}
+                           INTERFACE VIENNARAY_EMBREE_VERSION=${VIENNARAY_EMBREE_VERSION})
 
 if(VIENNARAY_USE_WDIST)
   message(STATUS "[ViennaRay] Using weighted distribution of ray weights")
@@ -64,10 +66,6 @@ endif()
 if(EMBREE_RAY_MASK)
   message(STATUS "[ViennaRay] Using embree ray masking")
   target_compile_definitions(${PROJECT_NAME} INTERFACE VIENNARAY_USE_RAY_MASKING)
-endif()
-
-if(VIENNARAY_EMBREE_VERSION)
-  target_compile_definitions(${PROJECT_NAME} INTERFACE VIENNARAY_EMBREE_VERSION=${VIENNARAY_EMBREE_VERSION}) 
 endif()
 
 # --------------------------------------------------------------------------------------------------------
@@ -89,7 +87,7 @@ CPMAddPackage(
   VERSION 1.11.1
   GIT_REPOSITORY "https://github.com/TheLartians/PackageProject.cmake")
 
-if (NOT VIENNARAY_SYSTEM_EMBREE)
+if(NOT VIENNARAY_SYSTEM_EMBREE)
   CPMFindPackage(
     NAME TBB
     VERSION 2020.0
@@ -98,10 +96,8 @@ if (NOT VIENNARAY_SYSTEM_EMBREE)
     OPTIONS "TBB_TEST OFF" "TBB_STRICT OFF")
 endif()
 
-if (VIENNARAY_EMBREE_VERSION EQUAL 3)
-  CPMFindPackage(
-    NAME embree
-    VERSION ${VIENNARAY_EMBREE_VERSION})
+if(VIENNARAY_EMBREE_VERSION EQUAL 3)
+  CPMFindPackage(NAME embree VERSION ${VIENNARAY_EMBREE_VERSION})
 else(VIENNARAY_EMBREE_VERSION)
   CPMFindPackage(
     NAME embree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,20 @@ option(VIENNARAY_BUILD_TESTS "Build tests" OFF)
 
 include("cmake/openmp.cmake")
 
-find_package(embree 3 QUIET)
+find_package(embree 4 QUIET)
 set(VIENNARAY_SYSTEM_EMBREE ${embree_FOUND})
+if (VIENNARAY_SYSTEM_EMBREE)
+  message(STATUS "[ViennaRay] Found embree 4 system installation")
+  set(VIENNARAY_EMBREE_VERSION 4)
+else(VIENNARAY_SYSTEM_EMBREE)
+  # look for embree 3
+  find_package(embree 3 QUIET)
+  set(VIENNARAY_SYSTEM_EMBREE ${embree_FOUND})
+  if (VIENNARAY_SYSTEM_EMBREE)
+    message(STATUS "[ViennaRay] Found embree 3 system installation")
+    set(VIENNARAY_EMBREE_VERSION 3)
+  endif()
+endif()
 
 if (NOT VIENNARAY_SYSTEM_EMBREE)
   message(STATUS "[ViennaRay] Using remote embree")
@@ -46,12 +58,16 @@ set_target_properties(
 
 if(VIENNARAY_USE_WDIST)
   message(STATUS "[ViennaRay] Using weighted distribution of ray weights")
-  target_compile_definitions(${PROJECT_NAME} PUBLIC VIENNARAY_USE_WDIST)
+  target_compile_definitions(${PROJECT_NAME} INTERFACE VIENNARAY_USE_WDIST)
 endif()
 
 if(EMBREE_RAY_MASK)
   message(STATUS "[ViennaRay] Using embree ray masking")
-  target_compile_definitions(${PROJECT_NAME} PUBLIC VIENNARAY_USE_RAY_MASKING)
+  target_compile_definitions(${PROJECT_NAME} INTERFACE VIENNARAY_USE_RAY_MASKING)
+endif()
+
+if(VIENNARAY_EMBREE_VERSION)
+  target_compile_definitions(${PROJECT_NAME} INTERFACE VIENNARAY_EMBREE_VERSION=${VIENNARAY_EMBREE_VERSION}) 
 endif()
 
 # --------------------------------------------------------------------------------------------------------
@@ -84,8 +100,7 @@ endif()
 
 CPMFindPackage(
   NAME embree
-  VERSION 3.0
-  GIT_TAG v3.13.0
+  VERSION ${VIENNARAY_EMBREE_VERSION}
   GIT_REPOSITORY "https://github.com/embree/embree"
   OPTIONS "EMBREE_TUTORIALS OFF")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if(VIENNARAY_USE_WDIST)
   target_compile_definitions(${PROJECT_NAME} INTERFACE VIENNARAY_USE_WDIST)
 endif()
 
-if(EMBREE_RAY_MASK)
+if(EMBREE_RAY_MASK OR VIENNARAY_EMBREE_VERSION EQUAL 4)
   message(STATUS "[ViennaRay] Using embree ray masking")
   target_compile_definitions(${PROJECT_NAME} INTERFACE VIENNARAY_USE_RAY_MASKING)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(
   ViennaRay
   LANGUAGES CXX
-  VERSION 2.0.0)
+  VERSION 2.0.1)
 
 # --------------------------------------------------------------------------------------------------------
 # Library options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,11 @@ option(VIENNARAY_BUILD_TESTS "Build tests" OFF)
 
 include("cmake/openmp.cmake")
 
-find_package(embree 4 QUIET)
+set(VIENNARAY_EMBREE_VERSION 4)
+find_package(embree ${VIENNARAY_EMBREE_VERSION} QUIET)
 set(VIENNARAY_SYSTEM_EMBREE ${embree_FOUND})
 if (VIENNARAY_SYSTEM_EMBREE)
   message(STATUS "[ViennaRay] Found embree 4 system installation")
-  set(VIENNARAY_EMBREE_VERSION 4)
 else(VIENNARAY_SYSTEM_EMBREE)
   # look for embree 3
   find_package(embree 3 QUIET)
@@ -98,11 +98,18 @@ if (NOT VIENNARAY_SYSTEM_EMBREE)
     OPTIONS "TBB_TEST OFF" "TBB_STRICT OFF")
 endif()
 
-CPMFindPackage(
-  NAME embree
-  VERSION ${VIENNARAY_EMBREE_VERSION}
-  GIT_REPOSITORY "https://github.com/embree/embree"
-  OPTIONS "EMBREE_TUTORIALS OFF")
+if (VIENNARAY_EMBREE_VERSION EQUAL 3)
+  CPMFindPackage(
+    NAME embree
+    VERSION ${VIENNARAY_EMBREE_VERSION})
+else(VIENNARAY_EMBREE_VERSION)
+  CPMFindPackage(
+    NAME embree
+    VERSION ${VIENNARAY_EMBREE_VERSION}
+    GIT_TAG v4.3.1
+    GIT_REPOSITORY "https://github.com/embree/embree"
+    OPTIONS "EMBREE_TUTORIALS OFF")
+endif()
 
 find_package(OpenMP REQUIRED)
 target_link_libraries(${PROJECT_NAME} INTERFACE OpenMP::OpenMP_CXX embree)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We recommend using [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to consum
   find_package(TBB    REQUIRED)
   find_package(OpenMP REQUIRED)
 
-  find_package(embree 3    PATHS ${VIENNARAY_PATH})
+  find_package(embree 4    PATHS ${VIENNARAY_PATH})
   find_package(ViennaRay   PATHS ${VIENNARAY_PATH})
 
   target_link_libraries(${PROJECT_NAME} PUBLIC ViennaTools::ViennaRay)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git clone https://github.com/ViennaTools/ViennaRay.git
 cd ViennaRay
 
 cmake -B build -DCMAKE_INSTALL_PREFIX=/path/to/your/custom/install/
+cmake --build build
 cmake --install build
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 <h1>ViennaRay</h1>
 
+[![🧪 Tests](https://github.com/ViennaTools/ViennaRay/actions/workflows/test.yml/badge.svg)](https://github.com/ViennaTools/ViennaRay/actions/workflows/test.yml)
+
 </div>
 
 ViennaRay is a flux calculation library for topography simulations, based in Intel®'s ray tracing kernel [Embree](https://www.embree.org/). It is designed to provide efficient and high-performance ray tracing, while maintaining a simple and easy to use interface. ViennaRay was developed and optimized for use in conjunction with [ViennaLS](https://github.com/ViennaTools/ViennaLS), which provides the necessary geometry representation. It is however possible to use this as a standalone library, with self-designed geometries.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We recommend using [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to consum
 * Installation with CPM
 
   ```cmake
-  CPMAddPackage("gh:viennatools/viennaray@2.0.0")
+  CPMAddPackage("gh:viennatools/viennaray@2.0.1")
   ```
 
 * With a local installation

--- a/cmake/embree.cmake
+++ b/cmake/embree.cmake
@@ -1,5 +1,7 @@
 macro(setup_embree_env TARGET OUTPUT)
-  if(VIENNARAY_DISABLE_COPY OR NOT MSVC OR VIENNARAY_SYSTEM_EMBREE)
+  if(VIENNARAY_DISABLE_COPY
+     OR NOT MSVC
+     OR VIENNARAY_SYSTEM_EMBREE)
     message(STATUS "[ViennaRay] Skipping Embree-Environment setup for ${TARGET}")
   else()
     message(STATUS "[ViennaRay] Setting up Embree-Environment for ${TARGET}")

--- a/examples/trench/CMakeLists.txt
+++ b/examples/trench/CMakeLists.txt
@@ -2,5 +2,6 @@ project(trench LANGUAGES CXX)
 
 add_executable(${PROJECT_NAME} "${PROJECT_NAME}.cpp")
 target_link_libraries(${PROJECT_NAME} PRIVATE ViennaRay)
+configure_file(trenchGrid3D.dat ${CMAKE_CURRENT_BINARY_DIR}/trenchGrid3D.dat COPYONLY)
 
 add_dependencies(ViennaRay_Examples ${PROJECT_NAME})

--- a/examples/trench2D/CMakeLists.txt
+++ b/examples/trench2D/CMakeLists.txt
@@ -2,5 +2,6 @@ project(trench2D LANGUAGES CXX)
 
 add_executable(${PROJECT_NAME} "${PROJECT_NAME}.cpp")
 target_link_libraries(${PROJECT_NAME} PRIVATE ViennaRay)
+configure_file(trenchGrid2D.dat ${CMAKE_CURRENT_BINARY_DIR}/trenchGrid2D.dat COPYONLY)
 
 add_dependencies(ViennaRay_Examples ${PROJECT_NAME})

--- a/include/viennaray/rayGeometry.hpp
+++ b/include/viennaray/rayGeometry.hpp
@@ -1,7 +1,6 @@
 #ifndef RAY_GEOMETRY_HPP
 #define RAY_GEOMETRY_HPP
 
-#include <embree3/rtcore.h>
 #include <rayMetaGeometry.hpp>
 #include <rayUtil.hpp>
 

--- a/include/viennaray/rayMetaGeometry.hpp
+++ b/include/viennaray/rayMetaGeometry.hpp
@@ -1,7 +1,11 @@
 #ifndef RAY_METAGEOMETRY_HPP
 #define RAY_METAGEOMETRY_HPP
 
+#if VIENNARAY_EMBREE_VERSION < 4
 #include <embree3/rtcore.h>
+#else
+#include <embree4/rtcore.h>
+#endif
 #include <rayUtil.hpp>
 
 template <typename NumericType, int D> class rayMetaGeometry {

--- a/include/viennaray/raySource.hpp
+++ b/include/viennaray/raySource.hpp
@@ -1,7 +1,11 @@
 #ifndef RAY_SOURCE_HPP
 #define RAY_SOURCE_HPP
 
+#if VIENNARAY_EMBREE_VERSION < 4
 #include <embree3/rtcore.h>
+#else
+#include <embree4/rtcore.h>
+#endif
 #include <rayPreCompileMacros.hpp>
 #include <rayRNG.hpp>
 #include <rayUtil.hpp>

--- a/include/viennaray/rayTrace.hpp
+++ b/include/viennaray/rayTrace.hpp
@@ -1,7 +1,6 @@
 #ifndef RAY_TRACE_HPP
 #define RAY_TRACE_HPP
 
-#include <embree3/rtcore.h>
 #include <rayBoundary.hpp>
 #include <rayGeometry.hpp>
 #include <rayHitCounter.hpp>

--- a/include/viennaray/rayTraceKernel.hpp
+++ b/include/viennaray/rayTraceKernel.hpp
@@ -115,8 +115,10 @@ public:
       // probabilistic weight
       const NumericType initialRayWeight = 1.;
 
+#ifdef VIENNARAY_EMBREE_VERSION < 4
       auto rtcContext = RTCIntersectContext{};
       rtcInitIntersectContext(&rtcContext);
+#endif
 
       [[maybe_unused]] size_t progressCount = 0;
 
@@ -150,7 +152,12 @@ public:
           // source
 
           // Run the intersection
+#ifdef VIENNARAY_EMBREE_VERSION < 4
           rtcIntersect1(rtcScene, &rtcContext, &rayHit);
+#else
+          rtcIntersect1(rtcScene, &rayHit);
+#endif
+
           ++totaltraces;
 
           /* -------- No hit -------- */

--- a/include/viennaray/rayTraceKernel.hpp
+++ b/include/viennaray/rayTraceKernel.hpp
@@ -115,7 +115,7 @@ public:
       // probabilistic weight
       const NumericType initialRayWeight = 1.;
 
-#ifdef VIENNARAY_EMBREE_VERSION < 4
+#if VIENNARAY_EMBREE_VERSION < 4
       auto rtcContext = RTCIntersectContext{};
       rtcInitIntersectContext(&rtcContext);
 #endif
@@ -152,7 +152,7 @@ public:
           // source
 
           // Run the intersection
-#ifdef VIENNARAY_EMBREE_VERSION < 4
+#if VIENNARAY_EMBREE_VERSION < 4
           rtcIntersect1(rtcScene, &rtcContext, &rayHit);
 #else
           rtcIntersect1(rtcScene, &rayHit);

--- a/include/viennaray/rayUtil.hpp
+++ b/include/viennaray/rayUtil.hpp
@@ -40,8 +40,8 @@ namespace rayInternal {
 constexpr double PI = 3.14159265358979323846;
 
 template <int D>
-constexpr double DiskFactor =
-    0.5 * (D == 3 ? 1.7320508 : 1.41421356237) * (1 + 1e-5);
+constexpr double DiskFactor = 0.5 * (D == 3 ? 1.7320508 : 1.41421356237) *
+                              (1 + 1e-5);
 
 /* ------------- Vector operation functions ------------- */
 template <typename NumericType>

--- a/tests/boundaryHit/boundaryHit.cpp
+++ b/tests/boundaryHit/boundaryHit.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayBoundary.hpp>
 #include <rayGeometry.hpp>
 #include <rayTestAsserts.hpp>

--- a/tests/boundaryHit2D/boundaryHit2D.cpp
+++ b/tests/boundaryHit2D/boundaryHit2D.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayBoundary.hpp>
 #include <rayGeometry.hpp>
 #include <rayTestAsserts.hpp>

--- a/tests/buildBoundary/buildBoundary.cpp
+++ b/tests/buildBoundary/buildBoundary.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayTestAsserts.hpp>
 #include <rayTrace.hpp>
 

--- a/tests/buildBoundary2D/buildBoundary2D.cpp
+++ b/tests/buildBoundary2D/buildBoundary2D.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayTestAsserts.hpp>
 #include <rayTrace.hpp>
 

--- a/tests/createGeometry/createGeometry.cpp
+++ b/tests/createGeometry/createGeometry.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayGeometry.hpp>
 #include <rayTestAsserts.hpp>
 

--- a/tests/createRay/createRay.cpp
+++ b/tests/createRay/createRay.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayGeometry.hpp>
 #include <rayRNG.hpp>
 #include <raySourceGrid.hpp>

--- a/tests/intersectionTest/intersectionTest.cpp
+++ b/tests/intersectionTest/intersectionTest.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayBoundary.hpp>
 #include <rayGeometry.hpp>
 #include <rayTestAsserts.hpp>
@@ -51,8 +50,10 @@ int main() {
   auto geometryID = rtcAttachGeometry(rtcscene, rtcgeometry);
   rtcJoinCommitScene(rtcscene);
 
+#if VIENNARAY_EMBREE_VERSION < 4
   auto rtccontext = RTCIntersectContext{};
   rtcInitIntersectContext(&rtccontext);
+#endif
   RAYTEST_ASSERT(rtcGetDeviceError(rtcDevice) == RTC_ERROR_NONE)
 
   {
@@ -79,7 +80,11 @@ int main() {
     rayhit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
     rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID;
 
+#if VIENNARAY_EMBREE_VERSION < 4
     rtcIntersect1(rtcscene, &rtccontext, &rayhit);
+#else
+    rtcIntersect1(rtcscene, &rayhit);
+#endif
 
     RAYTEST_ASSERT(rayhit.hit.geomID == geometryID)
     RAYTEST_ASSERT(rayhit.hit.primID == 840)
@@ -110,7 +115,11 @@ int main() {
     rayhit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
     rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID;
 
+#if VIENNARAY_EMBREE_VERSION < 4
     rtcIntersect1(rtcscene, &rtccontext, &rayhit);
+#else
+    rtcIntersect1(rtcscene, &rayhit);
+#endif
 
     RAYTEST_ASSERT(rayhit.hit.geomID == boundaryID)
     RAYTEST_ASSERT(rayhit.hit.primID == 7)

--- a/tests/pointNeighborhood/pointNeighborhood.cpp
+++ b/tests/pointNeighborhood/pointNeighborhood.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayGeometry.hpp>
 #include <rayTestAsserts.hpp>
 #include <rayUtil.hpp>

--- a/tests/pointNeighborhood2D/pointNeighborhood2D.cpp
+++ b/tests/pointNeighborhood2D/pointNeighborhood2D.cpp
@@ -1,4 +1,3 @@
-#include <embree3/rtcore.h>
 #include <rayGeometry.hpp>
 #include <rayTestAsserts.hpp>
 


### PR DESCRIPTION
Upgrade default Embree to version 4 (fixes #41 ). System installations of Embree 3 are still supported.